### PR TITLE
use legacy gas

### DIFF
--- a/packages/page-deploy/src/New.tsx
+++ b/packages/page-deploy/src/New.tsx
@@ -72,9 +72,8 @@ function New({ allCodes, className, navigateTo }: Props): React.ReactElement<Pro
       const factory = new ContractFactory(abi, bytecode, signer);
       const contract = await factory.deploy(...values.map(x => x.value), {
         gasLimit: BigNumber.from(34132001n),
+        gasPrice: BigNumber.from(200786445289n),
         value: endowment ? (endowment.isZero() ? undefined : endowment) : undefined,
-        maxFeePerGas: BigNumber.from(200786445289n),
-        maxPriorityFeePerGas: BigNumber.from(2)
       });
 
 


### PR DESCRIPTION
## Change
metamask will complain about tx format if we use 1559 (even our chain supports it), so fall back to use legacy gas format for now

## Test
tested locally and it's now able to deploy/call hello world